### PR TITLE
Add type declaration file

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -7,6 +7,7 @@ module.exports = {
     'eslint:recommended',
     'codex',
   ],
+  ignorePatterns: [ 'src/index.d.ts' ],
   overrides: [
     {
       env: {

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Vite plugin for sending sourcemaps to Hawk.
 
 ## Install
 ```
-yarn add @hawk.so/vite-plugin --save-dev
+yarn add @hawk.so/vite-plugin -D
 ```
 
 ## Connect

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hawk.so/vite-plugin",
   "description": "Vite plugin for sending source-maps to the Hawk",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "main": "src/index.js",
   "repository": "https://github.com/codex-team/hawk.vite.plugin.git",
   "author": "CodeX <team@codex.so>",

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,0 +1,33 @@
+/**
+ * Represents plugin options
+ */
+interface HawkVitePluginOptions {
+  /**
+   * Hawk integration token
+   */
+  token: string;
+
+  /**
+   * Unique identifier of the release
+   */
+  release?: string;
+
+  /**
+   * Whether to remove sourcemaps after uploading
+   */
+  removeSourceMaps?: boolean;
+
+  /**
+   * Sourcemaps collector endpoint overwrite
+   */
+  collectorEndpoint?: string
+}
+
+/**
+ * Vite plugin that uploads sourcemaps to Hawk
+ * and exposes release id to be available in global scope
+ * @param options - plugin options
+ */
+declare function hawkVitePlugin(options: HawkVitePluginOptions): unknown;
+
+export = hawkVitePlugin

--- a/src/index.js
+++ b/src/index.js
@@ -38,7 +38,7 @@ export default function hawkVitePlugin({
     release = new Date();
   }
 
-  let outDir;
+  let outDir = 'dist';
 
   return {
     name: 'hawk-vite-plugin',
@@ -46,7 +46,9 @@ export default function hawkVitePlugin({
       /**
        * Save build dir
        */
-      outDir = config.build.outDir || 'dist';
+      if (config.build && config.build.outDir) {
+        outDir = config.build.outDir;
+      }
 
       /**
        * Add sourcemap setting to vite config


### PR DESCRIPTION
- Add type declaration file (`index.d.ts`) 
- Fix error occurring when vite config does not have `build` section
- Fix error in readme