### PR TITLE
fix(sourcemaps): use hidden sourcemaps

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hawk.so/vite-plugin",
   "description": "Vite plugin for sending source-maps to the Hawk",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "main": "src/index.js",
   "repository": "https://github.com/codex-team/hawk.vite.plugin.git",
   "author": "CodeX <team@codex.so>",

--- a/src/index.js
+++ b/src/index.js
@@ -55,7 +55,7 @@ export default function hawkVitePlugin({
        */
       return {
         build: {
-          sourcemap: true,
+          sourcemap: removeSourceMaps ? 'hidden' : true,
         },
       };
     },


### PR DESCRIPTION
This plugin adds `sourcemaps` option to vite config. But now is simply "true" — sources maps will be generated and linked to code. 

This tool also removes source maps files after build. Not it leads 404 errors: source map is linked but file is removed.

The fix is in using of "hidden" source maps: they will be generated, but not linked in code.