### PR TITLE
chore(fetch): add timeout for sending

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hawk.so/vite-plugin",
   "description": "Vite plugin for sending source-maps to the Hawk",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "main": "src/index.js",
   "repository": "https://github.com/codex-team/hawk.vite.plugin.git",
   "author": "CodeX <team@codex.so>",

--- a/src/index.js
+++ b/src/index.js
@@ -176,6 +176,7 @@ async function sendSourceMapFile(filePath, collectorEndpoint, token, releaseId) 
       headers: {
         Authorization: `Bearer ${token}`,
       },
+      signal: AbortSignal.timeout(4500),
     });
 
     const responseData = await response.json();


### PR DESCRIPTION
When collector is not responding enough faster, build can be frozen. 

This PR adds a timeout for sending release info.