### PR TITLE
fix: support sourcemaps stored in chunk.map

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -148,15 +148,15 @@ function getSourceMapsFileNames(bundlesInfo) {
   return Object.values(bundlesInfo)
     .flatMap(item => {
       if (item.type === 'asset' && item.fileName.endsWith('.map')) {
-        return [item.fileName]
+        return [item.fileName];
       }
 
       if (item.type === 'chunk' && item.map) {
-        return [item.fileName + '.map']
+        return [item.fileName + '.map'];
       }
 
-      return []
-    })
+      return [];
+    });
 }
 
 /**

--- a/src/index.js
+++ b/src/index.js
@@ -146,8 +146,17 @@ export default function hawkVitePlugin({
  */
 function getSourceMapsFileNames(bundlesInfo) {
   return Object.values(bundlesInfo)
-    .filter(item => item.type === 'asset' && item.fileName.endsWith('.map'))
-    .map(item => item.fileName);
+    .flatMap(item => {
+      if (item.type === 'asset' && item.fileName.endsWith('.map')) {
+        return [item.fileName]
+      }
+
+      if (item.type === 'chunk' && item.map) {
+        return [item.fileName + '.map']
+      }
+
+      return []
+    })
 }
 
 /**


### PR DESCRIPTION
Fix sourcemap detection for Vite builds.

In some Vite/Rollup configurations sourcemaps are not emitted as separate
assets but attached to chunks via the `map` property:

```js
{
  type: 'chunk', 
  fileName: 'chunk.js', 
  map: {...}
  // other props
}
```

The current implementation only checks for `asset` entries ending with `.map`,
which causes sourcemaps to be skipped.

This change adds support for chunk-based sourcemaps while preserving the
existing behaviour.